### PR TITLE
fix: remove post frame applySelectedValueToField() call

### DIFF
--- a/lib/src/widgets/reactive_text_field/autocomplete/autocomplete_decoration.dart
+++ b/lib/src/widgets/reactive_text_field/autocomplete/autocomplete_decoration.dart
@@ -98,10 +98,7 @@ class AutocompleteDecoration<K, T> extends HookWidget {
           effectiveController.selectAll();
           hasFinishedSelection.value = true;
         } else {
-          WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-            applySelectedValueToField();
-            hasFinishedSelection.value = false;
-          });
+          hasFinishedSelection.value = false;
         }
       },
       [options, selectedKey],


### PR DESCRIPTION
This seems to be unnecessary, and it caused a bug (called `onSelected` with the previous value)