### PR TITLE
fix: revert #3

### DIFF
--- a/lib/src/widgets/reactive_text_field/autocomplete/autocomplete_decoration.dart
+++ b/lib/src/widgets/reactive_text_field/autocomplete/autocomplete_decoration.dart
@@ -98,7 +98,10 @@ class AutocompleteDecoration<K, T> extends HookWidget {
           effectiveController.selectAll();
           hasFinishedSelection.value = true;
         } else {
-          hasFinishedSelection.value = false;
+          WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+            applySelectedValueToField();
+            hasFinishedSelection.value = false;
+          });
         }
       },
       [options, selectedKey],


### PR DESCRIPTION
It is needed when `CompositeNodeFieldClearBehavior.none` to reapply the "deleted" value