### PR TITLE
feat: platform widget, fix PortalDialog

### DIFF
--- a/lib/src/extensions/alignment_extensions.dart
+++ b/lib/src/extensions/alignment_extensions.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_portal/flutter_portal.dart';
+
+String _onlyCornersSupportedException(Alignment aligment) =>
+    'Only the four corners are supported, but $aligment is not.';
+
+extension CoreAlignmentExtensions on Alignment {
+  Aligned asAligned(TextDirection? direction) {
+    if (direction == TextDirection.ltr) {
+      return leftAligned;
+    }
+
+    if (direction == TextDirection.rtl) {
+      return rightAligned;
+    }
+
+    return naturalAligned;
+  }
+
+  Aligned get naturalAligned {
+    if (this == Alignment.topLeft) {
+      return const Aligned(
+        follower: Alignment.topLeft,
+        target: Alignment.bottomLeft,
+        shiftToWithinBound: AxisFlag(x: true, y: true),
+      );
+    }
+    if (this == Alignment.topRight) {
+      return const Aligned(
+        follower: Alignment.topRight,
+        target: Alignment.bottomRight,
+        shiftToWithinBound: AxisFlag(x: true, y: true),
+      );
+    }
+    if (this == Alignment.bottomLeft) {
+      return const Aligned(
+        follower: Alignment.bottomLeft,
+        target: Alignment.topLeft,
+        shiftToWithinBound: AxisFlag(x: true, y: true),
+      );
+    }
+    if (this == Alignment.bottomRight) {
+      return const Aligned(
+        follower: Alignment.bottomRight,
+        target: Alignment.topRight,
+        shiftToWithinBound: AxisFlag(x: true, y: true),
+      );
+    }
+
+    throw _onlyCornersSupportedException;
+  }
+
+  Aligned get leftAligned {
+    if (this == Alignment.topLeft || this == Alignment.topRight) {
+      return const Aligned(
+        follower: Alignment.topLeft,
+        target: Alignment.bottomLeft,
+        shiftToWithinBound: AxisFlag(x: true, y: true),
+      );
+    }
+    if (this == Alignment.bottomLeft || this == Alignment.bottomRight) {
+      return const Aligned(
+        follower: Alignment.bottomLeft,
+        target: Alignment.topLeft,
+        shiftToWithinBound: AxisFlag(x: true, y: true),
+      );
+    }
+
+    throw _onlyCornersSupportedException;
+  }
+
+  Aligned get rightAligned {
+    if (this == Alignment.topLeft || this == Alignment.topRight) {
+      return const Aligned(
+        follower: Alignment.topRight,
+        target: Alignment.bottomRight,
+        shiftToWithinBound: AxisFlag(x: true, y: true),
+      );
+    }
+    if (this == Alignment.bottomLeft || this == Alignment.bottomRight) {
+      return const Aligned(
+        follower: Alignment.bottomRight,
+        target: Alignment.topRight,
+        shiftToWithinBound: AxisFlag(x: true, y: true),
+      );
+    }
+
+    throw _onlyCornersSupportedException;
+  }
+}

--- a/lib/src/extensions/async_value_extensions.dart
+++ b/lib/src/extensions/async_value_extensions.dart
@@ -1,6 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-extension AsyncValueExtensions<T> on AsyncValue<T> {
+extension CoreAsyncValueExtensions<T> on AsyncValue<T> {
   AsyncValue<T> get toLoading {
     final _value = value;
     if (_value != null) {

--- a/lib/src/extensions/global_key_extensions.dart
+++ b/lib/src/extensions/global_key_extensions.dart
@@ -12,7 +12,7 @@ extension CoreGlobalKeyExtensions on GlobalKey {
     if (renderBox == null) {
       return null;
     } else {
-      return renderBox.size;
+      return renderBox.hasSize ? renderBox.size : null;
     }
   }
 

--- a/lib/src/extensions/global_key_extensions.dart
+++ b/lib/src/extensions/global_key_extensions.dart
@@ -1,0 +1,57 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+extension CoreGlobalKeyExtensions on GlobalKey {
+  Size? get maybeSize {
+    if (currentContext == null) {
+      return null;
+    }
+
+    final renderBox = currentContext!.findRenderObject() as RenderBox?;
+    if (renderBox == null) {
+      return null;
+    } else {
+      return renderBox.size;
+    }
+  }
+
+  Offset? get maybeOffset {
+    final renderBox = currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null) {
+      return null;
+    } else {
+      return renderBox.localToGlobal(Offset.zero);
+    }
+  }
+
+  Size get size => maybeSize ?? Size.zero;
+
+  Offset get offset => maybeOffset ?? Offset.zero;
+
+  Point get centerPoint {
+    if (offset == Offset.zero) {
+      return const Point(0, 0);
+    }
+
+    final centerX = offset.dx + (size.width / 2);
+    final centerY = offset.dy + (size.height / 2);
+
+    return Point(centerX, centerY);
+  }
+
+  Alignment getQuadrantAlignment(Size referenceRect) {
+    final halfWidth = referenceRect.width / 2;
+    final halfHeight = referenceRect.height / 2;
+
+    if (centerPoint.x < halfWidth && centerPoint.y < halfHeight) {
+      return Alignment.topLeft;
+    } else if (centerPoint.x >= halfWidth && centerPoint.y < halfHeight) {
+      return Alignment.topRight;
+    } else if (centerPoint.x < halfWidth && centerPoint.y >= halfHeight) {
+      return Alignment.bottomLeft;
+    } else {
+      return Alignment.bottomRight;
+    }
+  }
+}

--- a/lib/src/extensions/size_extensions.dart
+++ b/lib/src/extensions/size_extensions.dart
@@ -1,0 +1,30 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+extension CoreSizeExtensions on Size {
+  Offset keepWithin(Size size, Offset offset) {
+    double verticalDelta = 0.0;
+    double horizontalDelta = 0.0;
+
+    if (height < offset.dy + size.height) {
+      verticalDelta = height - (offset.dy + size.height);
+    }
+
+    if (width < offset.dx + size.width) {
+      horizontalDelta = width - (offset.dx + size.width);
+    }
+
+    return Offset(horizontalDelta, verticalDelta);
+  }
+
+  Point relativeCenter(Size size, Offset offset) {
+    final heightRatio = size.height / height;
+    final heightOffsetRatio = (offset.dy / height) + heightRatio / 2;
+
+    final widthRatio = size.width / width;
+    final widthOffsetRatio = (offset.dx / width) + widthRatio / 2;
+
+    return Point(widthOffsetRatio, heightOffsetRatio);
+  }
+}

--- a/lib/src/extensions/time_of_day_extensions.dart
+++ b/lib/src/extensions/time_of_day_extensions.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-extension TimeOfDayExtension on TimeOfDay {
+extension CoreTimeOfDayExtension on TimeOfDay {
   bool isBefore(TimeOfDay other, {bool inclusive = false}) {
     if (inclusive) {
       return toMinutes() < other.toMinutes() || isAt(other);
@@ -85,7 +85,7 @@ extension TimeOfDayExtension on TimeOfDay {
   }
 }
 
-extension NullableTimeOfDayExtension on TimeOfDay? {
+extension CoreNullableTimeOfDayExtension on TimeOfDay? {
   bool isBefore(TimeOfDay? other) {
     if (this == null || other == null) return false;
     return this!.toMinutes() < other.toMinutes();
@@ -130,13 +130,13 @@ extension NullableTimeOfDayExtension on TimeOfDay? {
   }
 }
 
-extension TimeOfDayListExtension on Iterable<TimeOfDay> {
+extension CoreTimeOfDayListExtension on Iterable<TimeOfDay> {
   TimeOfDay? get earliest => isEmpty ? null : reduce((value, element) => value.isBefore(element) ? value : element);
 
   TimeOfDay? get latest => isEmpty ? null : reduce((value, element) => value.isAfter(element) ? value : element);
 }
 
-extension NullableTimeOfDayListExtension on Iterable<TimeOfDay?> {
+extension CoreNullableTimeOfDayListExtension on Iterable<TimeOfDay?> {
   TimeOfDay? get earliest => where((time) => time != null).fold<TimeOfDay?>(
         null,
         (TimeOfDay? current, TimeOfDay? next) =>

--- a/lib/src/extensions/value_notifier_extensions.dart
+++ b/lib/src/extensions/value_notifier_extensions.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/foundation.dart';
+
+extension CoreBoolValueNotifierExtensions on ValueNotifier<bool> {
+  void toggle() => value = !value;
+  void setTrue() => value = true;
+  void setFalse() => value = true;
+}

--- a/lib/src/widgets/misc/portal_dialog.dart
+++ b/lib/src/widgets/misc/portal_dialog.dart
@@ -1,127 +1,61 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_portal/flutter_portal.dart';
-import 'package:v_flutter_core/src/hooks/use_effect_hooks.dart';
-import 'package:v_flutter_core/src/hooks/use_value_listener.dart';
+import 'package:v_flutter_core/src/extensions/alignment_extensions.dart';
+import 'package:v_flutter_core/src/extensions/global_key_extensions.dart';
+import 'package:v_flutter_core/src/hooks/hooks.dart';
 import 'package:v_flutter_core/src/widgets/misc/dismissible_portal_target.dart';
-import 'package:v_flutter_core/src/widgets/size_reporter.dart';
 
 class PortalDialog extends HookWidget {
   const PortalDialog({
     super.key,
     required this.builder,
-    required this.portalFollower,
+    required this.portalFollowerBuilder,
     this.barrierDecoration,
     this.anchor,
     this.barrierDismissible = true,
-    this.visible = false,
-    this.hideWhenPressed = const [
-      SingleActivator(LogicalKeyboardKey.escape),
-      SingleActivator(LogicalKeyboardKey.tab),
-      SingleActivator(LogicalKeyboardKey.enter),
-      SingleActivator(LogicalKeyboardKey.space),
-    ],
-  }) : _wrapInCard = false;
+    this.direction,
+  });
 
-  const PortalDialog.card({
-    super.key,
-    required this.builder,
-    required this.portalFollower,
-    this.barrierDecoration,
-    this.anchor,
-    this.barrierDismissible = true,
-    this.visible = false,
-    this.hideWhenPressed = const [
-      SingleActivator(LogicalKeyboardKey.escape),
-      SingleActivator(LogicalKeyboardKey.tab),
-      SingleActivator(LogicalKeyboardKey.enter),
-      SingleActivator(LogicalKeyboardKey.space),
-    ],
-  }) : _wrapInCard = true;
-
-  final bool _wrapInCard;
-  final Widget portalFollower;
-  final bool visible;
-  final List<SingleActivator> hideWhenPressed;
+  final Widget Function(bool isOpen, void Function(bool) setIsOpen) portalFollowerBuilder;
   final bool barrierDismissible;
   final Anchor? anchor;
   final BoxDecoration? barrierDecoration;
+  final TextDirection? direction;
   final Widget Function(BuildContext context, bool isOpen, void Function(bool) setIsOpen) builder;
 
   @override
   Widget build(BuildContext context) {
-    final globalKey = useState(GlobalKey());
+    final globalKey = useGlobalKey<State<StatefulWidget>>();
     final isMenuOpen = useState(false);
-    useValueListener(visible, () {
-      isMenuOpen.value = visible;
-    });
 
     final effectiveAnchor = () {
       if (anchor != null) {
         return anchor!;
       }
 
-      final quadrantAlignment = globalKey.value.getQuadrantAlignment(MediaQuery.of(context).size);
-      return _getAligned(quadrantAlignment);
+      final maybeSize = MediaQuery.maybeSizeOf(context);
+      if (maybeSize == null) {
+        return Aligned.center;
+      }
+
+      return globalKey.getQuadrantAlignment(maybeSize).asAligned(direction);
     }();
 
     return DismissiblePortalTarget(
       barrierDecoration: barrierDecoration,
       portalFollower: Builder(
-        builder: (context) {
-          return _KeepWithinViewport(
-            child: CallbackShortcuts(
-              bindings: Map.fromEntries(hideWhenPressed.map((e) => MapEntry(e, () => isMenuOpen.value = false))),
-              child: Stack(
-                children: [
-                  Focus(
-                    onKeyEvent: (node, event) =>
-                        hideWhenPressed.map((e) => e.accepts(event, HardwareKeyboard.instance)).isNotEmpty
-                            ? KeyEventResult.ignored
-                            : KeyEventResult.handled,
-                    autofocus: true,
-                    child: const SizedBox(width: 1, height: 1),
-                  ),
-                  Builder(
-                    builder: (context) {
-                      if (!_wrapInCard) {
-                        return portalFollower;
-                      }
-
-                      return HookBuilder(
-                        builder: (context) {
-                          final animationController = useAnimationController(
-                            duration: const Duration(milliseconds: 1000),
-                          );
-                          usePlainEffectOnce(() {
-                            animationController.forward();
-                          });
-
-                          return SizeTransition(
-                            sizeFactor: const AlwaysStoppedAnimation(0.17),
-                            child: Card(
-                              child: portalFollower,
-                            ),
-                          );
-                        },
-                      );
-                    },
-                  ),
-                ],
-              ),
-            ),
-          );
-        },
+        builder: (context) => portalFollowerBuilder(
+          isMenuOpen.value,
+          (bool value) => isMenuOpen.value = value,
+        ),
       ),
       visible: isMenuOpen.value,
       onOutsideClick: () => isMenuOpen.value = false,
       onOutsideScroll: () => isMenuOpen.value = false,
       anchor: effectiveAnchor,
       child: Builder(
-        key: globalKey.value,
+        key: globalKey,
         builder: (context) {
           return builder(
             context,
@@ -131,142 +65,5 @@ class PortalDialog extends HookWidget {
         },
       ),
     );
-  }
-}
-
-class _KeepWithinViewport extends StatelessWidget {
-  const _KeepWithinViewport({
-    required this.child,
-  });
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizeReporter.builder(
-      builder: (size, offset) {
-        final viewportSize = MediaQuery.sizeOf(context);
-        final viewportWidth = viewportSize.width;
-        final viewportHeight = viewportSize.height;
-
-        final effectiveYOffset = () {
-          final yOffset = offset?.dy ?? 0;
-
-          if (yOffset < 0) {
-            final negativeVerticalOverflow = yOffset / size.height;
-            return negativeVerticalOverflow * -1;
-          }
-          if (yOffset + size.height > viewportHeight) {
-            final positiveVerticalOverflow = yOffset + size.height - viewportHeight;
-            return (positiveVerticalOverflow / size.height) * -1;
-          }
-
-          return 0;
-        }();
-        final effectiveXOffset = () {
-          final xOffset = offset?.dx ?? 0;
-
-          if (xOffset < 0) {
-            final negativeHorizontalOverflow = xOffset / size.width;
-            return negativeHorizontalOverflow * -1;
-          }
-          if (xOffset + size.width > viewportWidth) {
-            final positiveHorizontalOverflow = xOffset + size.width - viewportWidth;
-            return (positiveHorizontalOverflow / size.width) * -1;
-          }
-
-          return 0;
-        }();
-
-        return AnimatedSlide(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOutQuint,
-          offset: Offset(effectiveXOffset.toDouble(), effectiveYOffset.toDouble()),
-          child: child,
-        );
-      },
-    );
-  }
-}
-
-Aligned _getAligned(Alignment alignment) {
-  if (alignment == Alignment.topLeft) {
-    return const Aligned(
-      follower: Alignment.topLeft,
-      target: Alignment.bottomLeft,
-    );
-  }
-  if (alignment == Alignment.topRight) {
-    return const Aligned(
-      follower: Alignment.topRight,
-      target: Alignment.bottomRight,
-    );
-  }
-  if (alignment == Alignment.bottomLeft) {
-    return const Aligned(
-      follower: Alignment.bottomLeft,
-      target: Alignment.topLeft,
-    );
-  }
-  if (alignment == Alignment.bottomRight) {
-    return const Aligned(
-      follower: Alignment.bottomRight,
-      target: Alignment.topRight,
-    );
-  }
-
-  return Aligned(
-    follower: alignment,
-    target: alignment,
-  );
-}
-
-extension on GlobalKey {
-  Size get size {
-    if (currentContext == null) {
-      return Size.zero;
-    }
-
-    final renderBox = currentContext!.findRenderObject() as RenderBox?;
-    if (renderBox == null) {
-      debugPrint('Could not find RenderBox when getSize');
-      return Size.zero;
-    } else {
-      return renderBox.size;
-    }
-  }
-
-  Offset? get offset {
-    final renderBox = currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox != null) {
-      return renderBox.localToGlobal(Offset.zero);
-    }
-    return null;
-  }
-
-  Point get centerPoint {
-    if (offset == null) {
-      return const Point(0, 0);
-    }
-
-    final centerX = offset!.dx + (size.width / 2);
-    final centerY = offset!.dy + (size.height / 2);
-
-    return Point(centerX, centerY);
-  }
-
-  Alignment getQuadrantAlignment(Size referenceRect) {
-    final halfWidth = referenceRect.width / 2;
-    final halfHeight = referenceRect.height / 2;
-
-    if (centerPoint.x < halfWidth && centerPoint.y < halfHeight) {
-      return Alignment.topLeft;
-    } else if (centerPoint.x >= halfWidth && centerPoint.y < halfHeight) {
-      return Alignment.topRight;
-    } else if (centerPoint.x < halfWidth && centerPoint.y >= halfHeight) {
-      return Alignment.bottomLeft;
-    } else {
-      return Alignment.bottomRight;
-    }
   }
 }

--- a/lib/src/widgets/misc/size_class_layout.dart
+++ b/lib/src/widgets/misc/size_class_layout.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+enum WindowSizeClass { compact, medium, expanded, large, extraLarge }
+
+WidgetBuilder? _builderOrNull(Widget? widget) => widget == null ? null : ((_) => widget);
+WidgetBuilder _builder(Widget widget) => (context) => widget;
+
+extension DoubleX on double {
+  WindowSizeClass get toWindowSizeClass {
+    return switch (this) {
+      < 600 => WindowSizeClass.compact,
+      < 840 => WindowSizeClass.medium,
+      < 1200 => WindowSizeClass.expanded,
+      < 1600 => WindowSizeClass.large,
+      _ => WindowSizeClass.extraLarge,
+    };
+  }
+}
+
+extension MediaQueryDataX on MediaQueryData {
+  WindowSizeClass get windowSizeClass => size.width.toWindowSizeClass;
+}
+
+extension SizeX on Size {
+  WindowSizeClass get windowSizeClass => width.toWindowSizeClass;
+}
+
+class SizeClassLayout extends HookWidget {
+  SizeClassLayout({
+    super.key,
+    required Widget orElse,
+    Widget? compact,
+    Widget? medium,
+    Widget? expanded,
+    Widget? large,
+    Widget? extraLarge,
+  })  : compact = _builderOrNull(compact),
+        medium = _builderOrNull(medium),
+        expanded = _builderOrNull(expanded),
+        large = _builderOrNull(large),
+        extraLarge = _builderOrNull(extraLarge),
+        orElse = _builder(orElse);
+
+  const SizeClassLayout.builder({
+    super.key,
+    this.compact,
+    this.medium,
+    this.expanded,
+    this.large,
+    this.extraLarge,
+    required this.orElse,
+  });
+
+  final WidgetBuilder? compact;
+  final WidgetBuilder? medium;
+  final WidgetBuilder? expanded;
+  final WidgetBuilder? large;
+  final WidgetBuilder? extraLarge;
+  final WidgetBuilder orElse;
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.maybeSizeOf(context);
+    assert(size != null, 'Size is null, cannot compute WindowSizeClass');
+    final effectiveSize = size?.windowSizeClass ?? (kIsWeb ? WindowSizeClass.expanded : WindowSizeClass.compact);
+    final widgetBuilder = useMemoized(
+      () =>
+          switch (effectiveSize) {
+            WindowSizeClass.compact => compact,
+            WindowSizeClass.medium => medium,
+            WindowSizeClass.expanded => expanded,
+            WindowSizeClass.large => large,
+            WindowSizeClass.extraLarge => extraLarge,
+          } ??
+          orElse,
+      [effectiveSize],
+    );
+
+    return widgetBuilder(context);
+  }
+}

--- a/lib/src/widgets/misc/target_platform_widget.dart
+++ b/lib/src/widgets/misc/target_platform_widget.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+WidgetBuilder? _builderOrNull(Widget? widget) => widget == null ? null : ((_) => widget);
+WidgetBuilder _builder(Widget widget) => (context) => widget;
+
+class TargetPlatformWidget extends HookWidget {
+  TargetPlatformWidget({
+    super.key,
+    required Widget orElse,
+    Widget? mobile,
+    Widget? desktop,
+    Widget? web,
+  })  : mobile = _builderOrNull(mobile),
+        desktop = _builderOrNull(desktop),
+        web = _builderOrNull(web),
+        orElse = _builder(orElse);
+
+  const TargetPlatformWidget.builder({
+    super.key,
+    this.mobile,
+    this.desktop,
+    this.web,
+    required this.orElse,
+  });
+
+  final WidgetBuilder? mobile;
+  final WidgetBuilder? desktop;
+  final WidgetBuilder? web;
+  final WidgetBuilder orElse;
+
+  @override
+  Widget build(BuildContext context) {
+    if (kIsWeb) {
+      return web?.call(context) ?? orElse(context);
+    }
+
+    final platform = Theme.of(context).platform;
+
+    return switch (platform) {
+      TargetPlatform.android || TargetPlatform.iOS => mobile?.call(context) ?? orElse(context),
+      TargetPlatform.macOS ||
+      TargetPlatform.windows ||
+      TargetPlatform.linux =>
+        desktop?.call(context) ?? orElse(context),
+      TargetPlatform.fuchsia => orElse(context),
+    };
+  }
+}

--- a/lib/src/widgets/reactive_text_field/autocomplete/raw_autocomplete_decoration.dart
+++ b/lib/src/widgets/reactive_text_field/autocomplete/raw_autocomplete_decoration.dart
@@ -233,7 +233,7 @@ class RawAutocompleteDecoration<K, T> extends HookWidget {
     return SizeReporter(
       onChange: (size, offset) {
         fieldWidth.value = size.width;
-        availableSpaceBelow.value = MediaQuery.sizeOf(context).height - ((offset?.dy ?? 0) + size.height);
+        availableSpaceBelow.value = MediaQuery.sizeOf(context).height - ((offset.dy) + size.height);
       },
       child: HookBuilder(
         builder: (context) {

--- a/lib/src/widgets/size_reporter.dart
+++ b/lib/src/widgets/size_reporter.dart
@@ -35,19 +35,23 @@ class SizeReporter extends HookWidget {
     return NotificationListener<SizeChangedLayoutNotification>(
       onNotification: (_) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          size.value = globalKey.size;
-          offset.value = globalKey.offset;
+          if (context.mounted) {
+            size.value = globalKey.size;
+            offset.value = globalKey.offset;
 
-          onChange?.call(globalKey.size, globalKey.offset);
+            onChange?.call(globalKey.size, globalKey.offset);
+          }
         });
         return true;
       },
       child: HookBuilder(
         builder: (context) {
           usePlainPostFrameEffect(() {
-            size.value = globalKey.size;
-            offset.value = globalKey.offset;
-            onChange?.call(size.value, offset.value);
+            if (context.mounted) {
+              size.value = globalKey.size;
+              offset.value = globalKey.offset;
+              onChange?.call(size.value, offset.value);
+            }
           });
 
           return SizeChangedLayoutNotifier(

--- a/lib/src/widgets/size_reporter.dart
+++ b/lib/src/widgets/size_reporter.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:v_flutter_core/src/hooks/hooks.dart';
 import 'package:v_flutter_core/src/hooks/use_effect_hooks.dart';
 
-Widget Function(Size, Offset?) _defaultBuilder(Widget child) {
-  return (Size size, Offset? offset) => child;
+Widget Function(Size, Offset) _defaultBuilder(Widget child) {
+  return (Size size, Offset offset) => child;
 }
 
 class SizeReporter extends HookWidget {
@@ -23,12 +24,12 @@ class SizeReporter extends HookWidget {
 
   final GlobalKey? childKey;
 
-  final Widget Function(Size size, Offset? offset) builder;
-  final void Function(Size size, Offset? offset)? onChange;
+  final Widget Function(Size size, Offset offset) builder;
+  final void Function(Size size, Offset offset)? onChange;
 
   @override
   Widget build(BuildContext context) {
-    final globalKey = childKey ?? useState(GlobalKey()).value;
+    final globalKey = childKey ?? useGlobalKey();
     final size = useValueNotifier(globalKey.size);
     final offset = useValueNotifier(globalKey.offset);
 
@@ -117,18 +118,20 @@ extension GlobalKeyX on GlobalKey {
 
     final renderBox = currentContext!.findRenderObject() as RenderBox?;
     if (renderBox == null) {
-      debugPrint('Could not find RenderBox when getSize');
+      debugPrint('Could not find RenderBox when trying to resolve size.');
       return Size.zero;
     } else {
       return renderBox.size;
     }
   }
 
-  Offset? get offset {
+  Offset get offset {
     final renderBox = currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox != null) {
+    if (renderBox == null) {
+      debugPrint('Could not find RenderBox when trying to resolve offset.');
+      return Offset.zero;
+    } else {
       return renderBox.localToGlobal(Offset.zero);
     }
-    return null;
   }
 }

--- a/lib/src/widgets/size_reporter.dart
+++ b/lib/src/widgets/size_reporter.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:v_flutter_core/src/extensions/global_key_extensions.dart';
 import 'package:v_flutter_core/src/hooks/hooks.dart';
 import 'package:v_flutter_core/src/hooks/use_effect_hooks.dart';
 
@@ -112,34 +113,4 @@ class SizedBy extends HookWidget {
       ],
     );
   }
-}
-
-extension GlobalKeyX on GlobalKey {
-  Size? get maybeSize {
-    if (currentContext == null) {
-      return null;
-    }
-
-    final renderBox = currentContext!.findRenderObject() as RenderBox?;
-    if (renderBox == null) {
-      debugPrint('Could not find RenderBox when trying to resolve size.');
-      return null;
-    } else {
-      return renderBox.size;
-    }
-  }
-
-  Offset? get maybeOffset {
-    final renderBox = currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox == null) {
-      debugPrint('Could not find RenderBox when trying to resolve offset.');
-      return null;
-    } else {
-      return renderBox.localToGlobal(Offset.zero);
-    }
-  }
-
-  Size get size => maybeSize ?? Size.zero;
-
-  Offset get offset => maybeOffset ?? Offset.zero;
 }

--- a/lib/src/widgets/size_reporter.dart
+++ b/lib/src/widgets/size_reporter.dart
@@ -4,9 +4,8 @@ import 'package:v_flutter_core/src/extensions/global_key_extensions.dart';
 import 'package:v_flutter_core/src/hooks/hooks.dart';
 import 'package:v_flutter_core/src/hooks/use_effect_hooks.dart';
 
-Widget Function(Size, Offset) _defaultBuilder(Widget child) {
-  return (Size size, Offset offset) => child;
-}
+Widget Function(Size?, Offset?) _defaultBuilder(Widget child) => (Size? size, Offset? offset) => child;
+void noOpOnChange(Size _, Offset __) {}
 
 class SizeReporter extends HookWidget {
   SizeReporter({
@@ -20,12 +19,12 @@ class SizeReporter extends HookWidget {
     super.key,
     this.childKey,
     required this.builder,
-    required this.onChange,
-  });
+    void Function(Size, Offset)? onChange,
+  }) : onChange = onChange ?? noOpOnChange;
 
   final GlobalKey? childKey;
 
-  final Widget Function(Size size, Offset offset) builder;
+  final Widget Function(Size? size, Offset? offset) builder;
   final void Function(Size size, Offset offset) onChange;
 
   void _onChange(Size? size, Offset? offset) {
@@ -66,8 +65,8 @@ class SizeReporter extends HookWidget {
               child: HookBuilder(
                 builder: (context) {
                   return builder(
-                    useValueListenable(size) ?? Size.zero,
-                    useValueListenable(offset) ?? Offset.zero,
+                    useValueListenable(size),
+                    useValueListenable(offset),
                   );
                 },
               ),

--- a/lib/v_flutter_core.dart
+++ b/lib/v_flutter_core.dart
@@ -55,6 +55,7 @@ export 'src/widgets/misc/ghost.dart';
 export 'src/widgets/misc/maybe_align.dart';
 export 'src/widgets/misc/portal_dialog.dart';
 export 'src/widgets/misc/tab_visibility_change_recognizer.dart';
+export 'src/widgets/misc/target_platform_widget.dart';
 export 'src/widgets/misc/uninteractable.dart';
 export 'src/widgets/misc/wide.dart';
 export 'src/widgets/progress_button/button_variants.dart';

--- a/lib/v_flutter_core.dart
+++ b/lib/v_flutter_core.dart
@@ -54,6 +54,7 @@ export 'src/widgets/misc/dismissible_portal_target.dart';
 export 'src/widgets/misc/ghost.dart';
 export 'src/widgets/misc/maybe_align.dart';
 export 'src/widgets/misc/portal_dialog.dart';
+export 'src/widgets/misc/size_class_layout.dart';
 export 'src/widgets/misc/tab_visibility_change_recognizer.dart';
 export 'src/widgets/misc/target_platform_widget.dart';
 export 'src/widgets/misc/uninteractable.dart';

--- a/lib/v_flutter_core.dart
+++ b/lib/v_flutter_core.dart
@@ -1,8 +1,11 @@
+export 'src/extensions/alignment_extensions.dart';
 export 'src/extensions/async_value_extensions.dart';
 export 'src/extensions/bool_extensions.dart';
 export 'src/extensions/build_context_extensions.dart';
 export 'src/extensions/function_extensions.dart';
+export 'src/extensions/global_key_extensions.dart';
 export 'src/extensions/list_extensions.dart';
+export 'src/extensions/size_extensions.dart';
 export 'src/extensions/time_of_day_extensions.dart';
 
 export 'src/hooks/change_notifier_hooks.dart';


### PR DESCRIPTION
This PR consists of:
- code organisation: moving extensions out into their own files, consistent naming (`Core<Model>Extensions`)
- some fixes of extension functions
- SImplifying `PortalDialog` 
  - remove the "close by keypress" feature as it did not work as it should, and was causing focus issues
  - Allow `flutter_portal` to do the "keep inside view bounds" feature if the follower would go out of the screen
- Introduce `SizeClassLayout` to support [Window size classes](https://m3.material.io/foundations/layout/applying-layout/window-size-classes)
- Introduce `TargetPlatformWidget` which can receive a `web`, `mobile`, `desktop` argument to render.