### PR TITLE
feat: reactive text field value changed

### DIFF
--- a/lib/src/widgets/reactive_text_field/reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field/reactive_text_field.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// THIS IS A FORK OF reactive_text_field of reactive_forms 16.1.1
-
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
 import 'package:flutter/gestures.dart';
@@ -18,6 +16,11 @@ import 'package:reactive_forms/reactive_forms.dart';
 ///
 /// A [ReactiveForm] ancestor is required.
 ///
+/// THIS IS A FORK OF reactive_text_field of reactive_forms 16.1.1
+/// https://github.com/joanpablo/reactive_forms/blob/16.1.1/lib/src/widgets/reactive_text_field.dart
+/// 
+/// Added the following:
+/// - [showErrorTextWhenEmpty]
 class ReactiveTextField<T> extends ReactiveFormField<T, String> {
   /// Creates a [ReactiveTextField] that contains a [TextField].
   ///

--- a/lib/src/widgets/reactive_text_field/reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field/reactive_text_field.dart
@@ -18,9 +18,10 @@ import 'package:reactive_forms/reactive_forms.dart';
 ///
 /// THIS IS A FORK OF reactive_text_field of reactive_forms 16.1.1
 /// https://github.com/joanpablo/reactive_forms/blob/16.1.1/lib/src/widgets/reactive_text_field.dart
-/// 
+///
 /// Added the following:
 /// - [showErrorTextWhenEmpty]
+/// - Update [onControlValueChanged] so that the cursor position is maintained when the value does not actually change.
 class ReactiveTextField<T> extends ReactiveFormField<T, String> {
   /// Creates a [ReactiveTextField] that contains a [TextField].
   ///
@@ -252,9 +253,22 @@ class _ReactiveTextFieldState<T> extends ReactiveFocusableFormFieldState<T, Stri
   @override
   void onControlValueChanged(dynamic value) {
     final effectiveValue = (value == null) ? '' : value.toString();
+    final currentValue = _textController.text;
+    final currentSelection = _textController.selection;
+
+    TextSelection updatedSelection;
+    if (effectiveValue == currentValue) {
+      updatedSelection = currentSelection.copyWith(
+        baseOffset: currentSelection.baseOffset.clamp(0, effectiveValue.length),
+        extentOffset: currentSelection.extentOffset.clamp(0, effectiveValue.length),
+      );
+    } else {
+      updatedSelection = TextSelection.collapsed(offset: effectiveValue.length);
+    }
+
     _textController.value = _textController.value.copyWith(
       text: effectiveValue,
-      selection: TextSelection.collapsed(offset: effectiveValue.length),
+      selection: updatedSelection,
       composing: TextRange.empty,
     );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
   flutter_portal: ^1.1.4
   gap: ^3.0.1
   hooks_riverpod: ^2.4.0
-  reactive_forms: ^16.1.0
+  # Ensure to keep  `/src/widgets/reactive_text_field/reactive_text_field.dart` in sync
+  reactive_forms: ^16.1.1
   reactive_forms_annotations: ^4.0.0
   riverpod: ^2.4.0
   riverpod_annotation: ^2.1.5


### PR DESCRIPTION
If `onControlValueChanged` is fired (eg: `control.updateValueAndValidity()`) but the actual value does not change, then the cursor position should be maintained