### PR TITLE
feat: useDelayedExecution

### DIFF
--- a/lib/src/hooks/use_delayed_execution.dart
+++ b/lib/src/hooks/use_delayed_execution.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:v_flutter_core/v_flutter_core.dart';
+
+/// Executes a callback function after a specified delay.
+///
+/// This hook allows for delayed execution of a callback function.
+/// The execution is cancelled if the widget is unmounted before the delay completes.
+void useDelayedExecution(
+  VoidCallback callback, {
+  required Duration delay,
+}) {
+  final savedCallback = useRef<VoidCallback>(() {});
+  usePlainEffect(() => savedCallback.value = callback);
+
+  final completer = useMemoized(() => Completer(), [delay]);
+
+  useEffect(
+    () {
+      final timer = Future.delayed(delay, () {
+        if (!completer.isCompleted) {
+          savedCallback.value();
+        }
+      });
+      return () {
+        timer.ignore();
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      };
+    },
+    [delay],
+  );
+}

--- a/lib/v_flutter_core.dart
+++ b/lib/v_flutter_core.dart
@@ -18,6 +18,7 @@ export 'src/hooks/use_async_effect_hooks.dart';
 export 'src/hooks/use_chained_animation_controller.dart';
 export 'src/hooks/use_cleanup.dart';
 export 'src/hooks/use_debounce_callback.dart';
+export 'src/hooks/use_delayed_execution.dart';
 export 'src/hooks/use_effect_hooks.dart';
 export 'src/hooks/use_global_key.dart';
 export 'src/hooks/use_interval.dart';


### PR DESCRIPTION
Adds `useDelayedExecution` which
```
/// Executes a callback function after a specified delay.
///
/// This hook allows for delayed execution of a callback function.
/// The execution is cancelled if the widget is unmounted before the delay completes.
```