### PR TITLE
feat: support RawAutocomplete's optionsViewOpenDirection

### DIFF
--- a/lib/src/widgets/reactive_text_field/autocomplete/autocomplete_decoration.dart
+++ b/lib/src/widgets/reactive_text_field/autocomplete/autocomplete_decoration.dart
@@ -30,6 +30,7 @@ class AutocompleteDecoration<K, T> extends HookWidget {
     required this.listBuilder,
     required this.control,
     this.groupBuilder = defaultGroupAutocompleteBuilder,
+    this.optionsViewOpenDirection = OptionsViewOpenDirection.down,
     this.valueBuilder,
     this.customBuilder,
     this.customWidget,
@@ -57,6 +58,7 @@ class AutocompleteDecoration<K, T> extends HookWidget {
   final Widget? customWidget;
   final FormControl<K> control;
   final Widget Function(ScrollController controller, List<Widget> children) listBuilder;
+  final OptionsViewOpenDirection optionsViewOpenDirection;
 
   CompositeValue<K, T>? get selectedValue => options.findByKey(selectedKey);
 
@@ -156,6 +158,7 @@ class AutocompleteDecoration<K, T> extends HookWidget {
       focusNode: effectiveFocusNode,
       controller: effectiveController,
       groupBuilder: groupBuilder,
+      optionsViewOpenDirection: optionsViewOpenDirection,
       jumpToFirstMatch: asYouTypeBehavior.isJumpToFirstMatch ? displayStringForOption : null,
       valueBuilder: (node, isSelected, isHighlighted, select) {
         if (valueBuilder != null) {

--- a/lib/src/widgets/reactive_text_field/autocomplete/raw_autocomplete_decoration.dart
+++ b/lib/src/widgets/reactive_text_field/autocomplete/raw_autocomplete_decoration.dart
@@ -105,6 +105,7 @@ class RawAutocompleteDecoration<K, T> extends HookWidget {
     required this.listBuilder,
     required this.control,
     this.jumpToFirstMatch,
+    this.optionsViewOpenDirection = OptionsViewOpenDirection.down,
     this.customBuilder,
     this.customWidget,
     this.onChanged,
@@ -126,6 +127,7 @@ class RawAutocompleteDecoration<K, T> extends HookWidget {
   final Widget? Function(String value)? customBuilder;
   final Widget? customWidget;
   final String Function(T)? jumpToFirstMatch;
+  final OptionsViewOpenDirection optionsViewOpenDirection;
   final Widget Function(DepthCompositeGroup<K, T> node, bool isHighlighted) groupBuilder;
   final Widget Function(
     DepthCompositeValue<K, T> node,
@@ -250,6 +252,7 @@ class RawAutocompleteDecoration<K, T> extends HookWidget {
             ),
             child: RawAutocomplete<DepthCompositeNode<K, T>>(
               textEditingController: effectiveController,
+              optionsViewOpenDirection: optionsViewOpenDirection,
               focusNode: effectiveFocusNode,
               fieldViewBuilder: (context, _, __, onFieldSubmitted) {
                 return HookBuilder(

--- a/lib/src/widgets/reactive_text_field/autocomplete/search_decoration.dart
+++ b/lib/src/widgets/reactive_text_field/autocomplete/search_decoration.dart
@@ -23,6 +23,7 @@ class SearchDecoration<K, T> extends HookWidget {
     this.offlineSearchContent,
     this.focusNode,
     required this.control,
+    this.optionsViewOpenDirection = OptionsViewOpenDirection.down,
     super.key,
   });
 
@@ -45,6 +46,7 @@ class SearchDecoration<K, T> extends HookWidget {
   final Widget? customWidget;
   final FormControl<K> control;
   final Widget Function(ScrollController controller, List<Widget> children) listBuilder;
+  final OptionsViewOpenDirection optionsViewOpenDirection;
 
   CompositeValue<K, T>? get selectedValue => options.findByKey(selectedKey);
 
@@ -138,6 +140,7 @@ class SearchDecoration<K, T> extends HookWidget {
       customWidget: customWidget,
       groupBuilder: groupBuilder,
       customBuilder: customBuilder,
+      optionsViewOpenDirection: optionsViewOpenDirection,
       valueBuilder: (node, isSelected, isHighlighted, select) {
         if (valueBuilder != null) {
           return valueBuilder!(node, isSelected, isHighlighted, select);


### PR DESCRIPTION
This PR adds the `optionsViewOpenDirection` to the `AutocompleteDecoration`.

Note: https://github.com/flutter/flutter/issues/147483