### PR TITLE
fix: define fallback defaultEditableTextContextMenuBuilder if behaviour misses

### DIFF
--- a/lib/src/widgets/reactive_text_field/delegating_reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field/delegating_reactive_text_field.dart
@@ -59,7 +59,7 @@ class DelegatingReactiveTextField<T> extends HookConsumerWidget {
         canRequestFocus: behavior.canRequestFocus ?? true,
         clipBehavior: theme.clipBehavior ?? Clip.hardEdge,
         contentInsertionConfiguration: behavior.contentInsertionConfiguration,
-        contextMenuBuilder: behavior.contextMenuBuilder,
+        contextMenuBuilder: behavior.contextMenuBuilder ?? defaultEditableTextContextMenuBuilder,
         controller: behavior.controller,
         cursorColor: theme.cursorColor,
         cursorHeight: theme.cursorHeight,

--- a/lib/src/widgets/reactive_text_field/reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field/reactive_text_field.dart
@@ -105,7 +105,7 @@ class ReactiveTextField<T> extends ReactiveFormField<T, String> {
     TextAlignVertical? textAlignVertical,
     bool autofocus = false,
     bool readOnly = false,
-    EditableTextContextMenuBuilder? contextMenuBuilder = _defaultContextMenuBuilder,
+    EditableTextContextMenuBuilder? contextMenuBuilder = defaultEditableTextContextMenuBuilder,
     bool? showCursor,
     bool obscureText = false,
     String obscuringCharacter = '•',
@@ -231,14 +231,14 @@ class ReactiveTextField<T> extends ReactiveFormField<T, String> {
         );
   final TextEditingController? _textController;
 
-  static Widget _defaultContextMenuBuilder(BuildContext context, EditableTextState editableTextState) {
-    return AdaptiveTextSelectionToolbar.editableText(
-      editableTextState: editableTextState,
-    );
-  }
-
   @override
   ReactiveFormFieldState<T, String> createState() => _ReactiveTextFieldState<T>();
+}
+
+Widget defaultEditableTextContextMenuBuilder(BuildContext context, EditableTextState editableTextState) {
+  return AdaptiveTextSelectionToolbar.editableText(
+    editableTextState: editableTextState,
+  );
 }
 
 class _ReactiveTextFieldState<T> extends ReactiveFocusableFormFieldState<T, String> {


### PR DESCRIPTION
Every other `ReactiveTextField` property is either `behavior.property [?? defaultValue]` (where there was actually a default value on the ReactiveTextField from the package). 
contextMenuBuilder was missing this fallback, thus passing `null`, so the context menu did not appear