### PR TITLE
chore/0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.11
+
+fix: properly clean up `ProviderSubscription` when the `streamOfAsyncData`/`streamOf` streams are cancelled
+
 ## 0.0.10
 
 fix: do not access BehaviorSubject value prematurely

--- a/lib/src/extensions/ref_extensions.dart
+++ b/lib/src/extensions/ref_extensions.dart
@@ -6,7 +6,7 @@ extension CoreRefExtensions on Ref<dynamic> {
   /// Returns a Stream of [AsyncData] values provided by [provider] (which provides items of [AsyncValue<T>] type).
   /// Especially useful to get the values of a provider, but
   /// do not rebuild [this] when the dependency rebuilds. ([ref.listen] is used internally)
-  Stream<T> streamOfAsyncData<T>(
+Stream<T> streamOfAsyncData<T>(
     AlwaysAliveProviderListenable<AsyncValue<T>> provider, {
     bool fireImmediately = false,
     bool skipError = true,
@@ -14,21 +14,36 @@ extension CoreRefExtensions on Ref<dynamic> {
     bool skipLoadingOnRefresh = true,
     bool broadcast = false,
   }) {
-    final StreamController<T> controller = broadcast ? StreamController.broadcast() : StreamController();
-    onDispose(() => controller.close());
+    late final StreamController<T> streamController;
+    ProviderSubscription<AsyncValue<T>>? providerSubscription;
 
-    listen(
-      provider,
-      (_, next) => next.whenOrNull(
-        data: (value) => controller.add(value),
-        error: (error, stackTrace) => skipError ? null : controller.addError(error, stackTrace),
-        skipLoadingOnRefresh: skipLoadingOnRefresh,
-        skipLoadingOnReload: skipLoadingOnReload,
-      ),
-      fireImmediately: fireImmediately,
-    );
+    void handleListen() {
+      providerSubscription = listen(
+        provider,
+        (_, next) => next.whenOrNull(
+          data: (value) => streamController.add(value),
+          error: (error, stackTrace) => skipError ? null : streamController.addError(error, stackTrace),
+          skipLoadingOnRefresh: skipLoadingOnRefresh,
+          skipLoadingOnReload: skipLoadingOnReload,
+        ),
+        fireImmediately: fireImmediately,
+      );
+    }
 
-    return controller.stream;
+    void cleanup() {
+      providerSubscription?.close();
+      streamController.close();
+    }
+
+    onDispose(() => cleanup());
+
+    if (broadcast) {
+      streamController = StreamController<T>.broadcast(onListen: handleListen, onCancel: cleanup);
+    } else {
+      streamController = StreamController<T>(onListen: handleListen, onCancel: cleanup);
+    }
+
+    return streamController.stream;
   }
 
   /// Returns a Stream of the values provided by [provider] (which provides items of [T] type).
@@ -39,14 +54,29 @@ extension CoreRefExtensions on Ref<dynamic> {
     bool fireImmediately = false,
     bool broadcast = false,
   }) {
-    final StreamController<T> controller = broadcast ? StreamController.broadcast() : StreamController();
-    onDispose(() => controller.close());
+    late final StreamController<T> controller;
+    ProviderSubscription<T>? providerSubscription;
 
-    listen(
-      provider,
-      (_, next) => controller.add(next),
-      fireImmediately: fireImmediately,
-    );
+    void handleListen() {
+      providerSubscription = listen(
+        provider,
+        (_, next) => controller.add(next),
+        fireImmediately: fireImmediately,
+      );
+    }
+
+    void cleanup() {
+      providerSubscription?.close();
+      controller.close();
+    }
+
+    onDispose(() => cleanup());
+
+    if (broadcast) {
+      controller = StreamController<T>.broadcast(onListen: handleListen, onCancel: cleanup);
+    } else {
+      controller = StreamController<T>(onListen: handleListen, onCancel: cleanup);
+    }
 
     return controller.stream;
   }
@@ -64,21 +94,36 @@ extension CoreAutoDisposeRefExtensions on AutoDisposeRef<dynamic> {
     bool skipLoadingOnRefresh = true,
     bool broadcast = false,
   }) {
-    final StreamController<T> controller = broadcast ? StreamController.broadcast() : StreamController();
-    onDispose(() => controller.close());
+    late final StreamController<T> streamController;
+    ProviderSubscription<AsyncValue<T>>? providerSubscription;
 
-    listen(
-      provider,
-      (_, next) => next.whenOrNull(
-        data: (value) => controller.add(value),
-        error: (error, stackTrace) => skipError ? null : controller.addError(error, stackTrace),
-        skipLoadingOnRefresh: skipLoadingOnRefresh,
-        skipLoadingOnReload: skipLoadingOnReload,
-      ),
-      fireImmediately: fireImmediately,
-    );
+    void handleListen() {
+      providerSubscription = listen(
+        provider,
+        (_, next) => next.whenOrNull(
+          data: (value) => streamController.add(value),
+          error: (error, stackTrace) => skipError ? null : streamController.addError(error, stackTrace),
+          skipLoadingOnRefresh: skipLoadingOnRefresh,
+          skipLoadingOnReload: skipLoadingOnReload,
+        ),
+        fireImmediately: fireImmediately,
+      );
+    }
 
-    return controller.stream;
+    void cleanup() {
+      providerSubscription?.close();
+      streamController.close();
+    }
+
+    onDispose(() => cleanup());
+
+    if (broadcast) {
+      streamController = StreamController<T>.broadcast(onListen: handleListen, onCancel: cleanup);
+    } else {
+      streamController = StreamController<T>(onListen: handleListen, onCancel: cleanup);
+    }
+
+    return streamController.stream;
   }
 
   /// Returns a Stream of the values provided by [provider] (which provides items of [T] type).
@@ -89,14 +134,29 @@ extension CoreAutoDisposeRefExtensions on AutoDisposeRef<dynamic> {
     bool fireImmediately = false,
     bool broadcast = false,
   }) {
-    final StreamController<T> controller = broadcast ? StreamController.broadcast() : StreamController();
-    onDispose(() => controller.close());
+    late final StreamController<T> controller;
+    ProviderSubscription<T>? providerSubscription;
 
-    listen(
-      provider,
-      (_, next) => controller.add(next),
-      fireImmediately: fireImmediately,
-    );
+    void handleListen() {
+      providerSubscription = listen(
+        provider,
+        (_, next) => controller.add(next),
+        fireImmediately: fireImmediately,
+      );
+    }
+
+    void cleanup() {
+      providerSubscription?.close();
+      controller.close();
+    }
+
+    onDispose(() => cleanup());
+
+    if (broadcast) {
+      controller = StreamController<T>.broadcast(onListen: handleListen, onCancel: cleanup);
+    } else {
+      controller = StreamController<T>(onListen: handleListen, onCancel: cleanup);
+    }
 
     return controller.stream;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: v_flutter_core
 description: vlabs core library
 repository: https://github.com/Vlabs-development/v_flutter_core
-version: 0.0.10
+version: 0.0.11
 
 environment:
   sdk: ^3.1.0


### PR DESCRIPTION
fix: properly clean up `ProviderSubscription` when the `streamOfAsyncData`/`streamOf` streams are cancelled