### PR TITLE
feat: add child padding option for separated column

### DIFF
--- a/lib/src/widgets/layout/flex/separated_column.dart
+++ b/lib/src/widgets/layout/flex/separated_column.dart
@@ -29,8 +29,8 @@ class SeparatedColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> paddedChildren =
-        children.map((child) => childPadding == null ? child : Padding(padding: childPadding!, child: child)).toList();
+    final paddedChildren =
+        children.map((child) => childPadding == null ? child : Padding(padding: childPadding!, child: child));
 
     return Column(
       mainAxisAlignment: mainAxisAlignment,

--- a/lib/src/widgets/layout/flex/separated_column.dart
+++ b/lib/src/widgets/layout/flex/separated_column.dart
@@ -13,6 +13,7 @@ class SeparatedColumn extends StatelessWidget {
     this.verticalDirection = VerticalDirection.down,
     this.textBaseline,
     this.clipBehavior = Clip.none,
+    this.childPadding,
   });
 
   final List<Widget> children;
@@ -24,9 +25,13 @@ class SeparatedColumn extends StatelessWidget {
   final VerticalDirection verticalDirection;
   final TextBaseline? textBaseline;
   final Clip clipBehavior;
+  final EdgeInsetsGeometry? childPadding;
 
   @override
   Widget build(BuildContext context) {
+    final List<Widget> paddedChildren =
+        children.map((child) => childPadding == null ? child : Padding(padding: childPadding!, child: child)).toList();
+
     return Column(
       mainAxisAlignment: mainAxisAlignment,
       mainAxisSize: mainAxisSize,
@@ -34,7 +39,7 @@ class SeparatedColumn extends StatelessWidget {
       textDirection: textDirection,
       verticalDirection: verticalDirection,
       textBaseline: textBaseline,
-      children: children.putBetween(separator),
+      children: paddedChildren.putBetween(separator),
     );
   }
 }

--- a/lib/src/widgets/layout/flex/separated_flex.dart
+++ b/lib/src/widgets/layout/flex/separated_flex.dart
@@ -3,6 +3,7 @@ import 'package:v_flutter_core/v_flutter_core.dart';
 
 class SeparatedFlex extends StatelessWidget {
   const SeparatedFlex({
+    super.key,
     required this.children,
     required this.direction,
     required this.separator,
@@ -13,7 +14,7 @@ class SeparatedFlex extends StatelessWidget {
     this.verticalDirection = VerticalDirection.down,
     this.textBaseline,
     this.clipBehavior = Clip.none,
-    super.key,
+    this.childPadding,
   });
 
   final List<Widget> children;
@@ -26,9 +27,13 @@ class SeparatedFlex extends StatelessWidget {
   final VerticalDirection verticalDirection;
   final TextBaseline? textBaseline;
   final Clip clipBehavior;
+  final EdgeInsetsGeometry? childPadding;
 
   @override
   Widget build(BuildContext context) {
+    final paddedChildren =
+        children.map((child) => childPadding == null ? child : Padding(padding: childPadding!, child: child));
+
     return Flex(
       direction: direction,
       mainAxisAlignment: mainAxisAlignment,
@@ -38,7 +43,7 @@ class SeparatedFlex extends StatelessWidget {
       verticalDirection: verticalDirection,
       textBaseline: textBaseline,
       clipBehavior: clipBehavior,
-      children: children.putBetween(separator),
+      children: paddedChildren.putBetween(separator),
     );
   }
 }

--- a/lib/src/widgets/layout/flex/separated_row.dart
+++ b/lib/src/widgets/layout/flex/separated_row.dart
@@ -13,6 +13,7 @@ class SeparatedRow extends StatelessWidget {
     this.verticalDirection = VerticalDirection.down,
     this.textBaseline,
     this.clipBehavior = Clip.none,
+    this.childPadding,
   });
 
   final List<Widget> children;
@@ -24,9 +25,13 @@ class SeparatedRow extends StatelessWidget {
   final VerticalDirection verticalDirection;
   final TextBaseline? textBaseline;
   final Clip clipBehavior;
+  final EdgeInsetsGeometry? childPadding;
 
   @override
   Widget build(BuildContext context) {
+    final paddedChildren =
+        children.map((child) => childPadding == null ? child : Padding(padding: childPadding!, child: child));
+
     return Row(
       mainAxisAlignment: mainAxisAlignment,
       mainAxisSize: mainAxisSize,
@@ -34,7 +39,7 @@ class SeparatedRow extends StatelessWidget {
       textDirection: textDirection,
       verticalDirection: verticalDirection,
       textBaseline: textBaseline,
-      children: children.putBetween(separator),
+      children: paddedChildren.putBetween(separator),
     );
   }
 }


### PR DESCRIPTION
When using separated column, ofter each child needs it's own padding (same for each child).
With this change it's possible to achieve this by using the `childPadding` prop instead of wrapping each child of the `SeparatedColumn`, 

Figma:

![image](https://github.com/user-attachments/assets/a160266a-c973-4b5c-8622-7eef0dae039c)

Impleneted UI:

![image](https://github.com/user-attachments/assets/609ca055-66e2-4415-9345-194d982be239)
