### PR TITLE
fix: `sync: true` `BehaviorSubject`

### DIFF
--- a/lib/src/extensions/ref_extensions.dart
+++ b/lib/src/extensions/ref_extensions.dart
@@ -6,10 +6,11 @@ extension CoreRefExtensions on Ref<dynamic> {
   /// Returns a Stream of [AsyncData] values provided by [provider] (which provides items of [AsyncValue<T>] type).
   /// Especially useful to get the values of a provider, but
   /// do not rebuild [this] when the dependency rebuilds. ([ref.listen] is used internally)
-Stream<T> streamOfAsyncData<T>(
+  Stream<T> streamOfAsyncData<T>(
     AlwaysAliveProviderListenable<AsyncValue<T>> provider, {
     bool fireImmediately = false,
     bool skipError = true,
+    Function(Object error, StackTrace stackTrace)? onError,
     bool skipLoadingOnReload = false,
     bool skipLoadingOnRefresh = true,
     bool broadcast = false,
@@ -22,7 +23,13 @@ Stream<T> streamOfAsyncData<T>(
         provider,
         (_, next) => next.whenOrNull(
           data: (value) => streamController.add(value),
-          error: (error, stackTrace) => skipError ? null : streamController.addError(error, stackTrace),
+          error: (error, stackTrace) {
+            onError?.call(error, stackTrace);
+
+            if (!skipError) {
+              streamController.addError(error, stackTrace);
+            }
+          },
           skipLoadingOnRefresh: skipLoadingOnRefresh,
           skipLoadingOnReload: skipLoadingOnReload,
         ),
@@ -90,6 +97,7 @@ extension CoreAutoDisposeRefExtensions on AutoDisposeRef<dynamic> {
     ProviderListenable<AsyncValue<T>> provider, {
     bool fireImmediately = false,
     bool skipError = true,
+    Function(Object error, StackTrace stackTrace)? onError,
     bool skipLoadingOnReload = false,
     bool skipLoadingOnRefresh = true,
     bool broadcast = false,
@@ -102,7 +110,13 @@ extension CoreAutoDisposeRefExtensions on AutoDisposeRef<dynamic> {
         provider,
         (_, next) => next.whenOrNull(
           data: (value) => streamController.add(value),
-          error: (error, stackTrace) => skipError ? null : streamController.addError(error, stackTrace),
+          error: (error, stackTrace) {
+            onError?.call(error, stackTrace);
+
+            if (!skipError) {
+              streamController.addError(error, stackTrace);
+            }
+          },
           skipLoadingOnRefresh: skipLoadingOnRefresh,
           skipLoadingOnReload: skipLoadingOnReload,
         ),

--- a/lib/src/extensions/stream_extensions.dart
+++ b/lib/src/extensions/stream_extensions.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:rxdart/rxdart.dart';
+
+extension CoreStreamExtensions<T> on Stream<T> {
+  Stream<T> printEvents(String name, {String? prefix = ''}) {
+    return doOnListen(() => debugPrint('👂 $prefix[$name] listen (isBroadcast: $isBroadcast)'))
+        .doOnData((event) => debugPrint('💡 $prefix[$name] data $event'))
+        .doOnCancel(() => debugPrint('💔 $prefix[$name] cancel'))
+        .doOnError((error, stackTrace) => debugPrint('❌ $prefix[$name] error $error $stackTrace'))
+        .doOnPause(() => debugPrint('💤 $prefix[$name] pause'))
+        .doOnResume(() => debugPrint('💪 $prefix[$name] resume'))
+        .doOnDone(() => debugPrint('🏁 $prefix[$name] done'));
+  }
+}

--- a/lib/src/utils/live_list.dart
+++ b/lib/src/utils/live_list.dart
@@ -98,7 +98,7 @@ class LiveList<ID, T> {
     _disposableList.addAllStreamSubscription(listDependencies.map((d) => _listDependencySubscription(d)));
   }
 
-  final _subject = BehaviorSubject<Iterable<T>>();
+  final _subject = BehaviorSubject<Iterable<T>>(sync: true);
   final _disposableList = DisposableList();
   final _disposableMapGroup = DisposableMapGroup<ID, String>();
   final _dependencyStreams = <ID, Map<String, Stream<String>>>{};

--- a/lib/v_flutter_core.dart
+++ b/lib/v_flutter_core.dart
@@ -8,6 +8,7 @@ export 'src/extensions/list_extensions.dart';
 export 'src/extensions/map_extensions.dart';
 export 'src/extensions/ref_extensions.dart';
 export 'src/extensions/size_extensions.dart';
+export 'src/extensions/stream_extensions.dart';
 export 'src/extensions/string_extensions.dart';
 export 'src/extensions/time_of_day_extensions.dart';
 export 'src/extensions/v_stream.dart';
@@ -37,8 +38,8 @@ export 'src/theme/mergeable_theme_extension/mergeable_theme_extension.dart';
 export 'src/utils/composite_node/composite_node.dart';
 export 'src/utils/composite_node/composite_node_value_accessor.dart';
 export 'src/utils/composite_node/depth_composite_node.dart';
-export 'src/utils/live_list.dart';
 export 'src/utils/handshake_completer.dart';
+export 'src/utils/live_list.dart';
 export 'src/utils/text_input_formatters/round_to_next_time_of_day_formatter.dart';
 export 'src/utils/type_checks.dart';
 


### PR DESCRIPTION
Making the `BehaviorSubject` sync allows the `LiveList` to emit the new items right after the change is made (eg with `upserItem` or any other dependent stream event)
This solves the case of the "placeholder screen is shown after contract is accepted" issue for clara clients.