### PR TITLE
feat: IgnoreHorizontalPaddingPivot

### DIFF
--- a/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
+++ b/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
@@ -8,14 +8,14 @@ typedef ChildWrapper = Widget Function({required Widget child});
 /// paddings that the are imposed on them after the pivot.
 /// ```dart
 ///IgnoreHorizontalPaddingPivot(
-///  builder: (context, ignorePaddingBuilder) {
+///  builder: (context, ignorePadding) {
 ///    return Padding(
 ///      padding: const EdgeInsets.only(left: 16, right: 24),
 ///      child: Column(
 ///        children: [
 ///          Header(),
 ///          Body(),
-///          ignorePaddingBuilder(child: Divider()),
+///          ignorePadding(child: Divider()),
 ///          Footer(),
 ///        ],
 ///      ),
@@ -29,7 +29,7 @@ class IgnoreHorizontalPaddingPivot extends StatelessWidget {
     super.key,
   });
 
-  final Widget Function(BuildContext context, ChildWrapper ignorePaddingBuilder) builder;
+  final Widget Function(BuildContext context, ChildWrapper ignorePadding) builder;
 
   @override
   Widget build(BuildContext context) => LayoutBuilder(

--- a/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
+++ b/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:v_flutter_core/src/widgets/misc/size_reporter.dart';
+
+typedef ChildWrapper = Widget Function({required Widget child});
+
+/// This widget is aware of its width. In its builder parameter it supplies a `ChildWrapper` function that can be used
+/// as any other widget (like `Container(child: ...)`). The widgets which are wrapped in this are ignoring the horizontal
+/// paddings that the are imposed on them after the pivot.
+/// ```dart
+///IgnoreHorizontalPaddingPivot(
+///  builder: (context, ignorePaddingBuilder) {
+///    return Padding(
+///      padding: const EdgeInsets.only(left: 16, right: 24),
+///      child: Column(
+///        children: [
+///          Header(),
+///          Body(),
+///          ignorePaddingBuilder(child: Divider()),
+///          Footer(),
+///        ],
+///      ),
+///    );
+///  },
+///);
+///```
+class IgnoreHorizontalPaddingPivot extends StatelessWidget {
+  const IgnoreHorizontalPaddingPivot({
+    required this.builder,
+    super.key,
+  });
+
+  final Widget Function(BuildContext context, ChildWrapper ignorePaddingBuilder) builder;
+
+  @override
+  Widget build(BuildContext context) => LayoutBuilder(
+        builder: (context, constraints) => SizeReporter.builder(
+          builder: (parentSize, parentOffset) => builder(
+            context,
+            ({required child}) => SizeReporter.builder(
+              builder: (size, offset) {
+                final parentDx = parentOffset?.dx ?? 0;
+                final parentWidth = parentSize?.width ?? 0;
+                final dx = offset?.dx ?? 0;
+                final width = size?.width ?? 0;
+                final translation = (parentDx + parentWidth / 2) - (dx + width / 2);
+
+                return IntrinsicHeight(
+                  child: OverflowBox(
+                    maxWidth: parentSize?.width ?? constraints.maxWidth,
+                    child: Transform.translate(
+                      offset: Offset(translation, 0),
+                      child: child,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+}

--- a/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
+++ b/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
@@ -8,14 +8,14 @@ typedef ChildWrapper = Widget Function({required Widget child});
 /// paddings that the are imposed on them after the pivot.
 /// ```dart
 ///IgnoreHorizontalPaddingPivot(
-///  builder: (context, ignorePadding) {
+///  builder: (context, ignoreHorizontalPadding) {
 ///    return Padding(
 ///      padding: const EdgeInsets.only(left: 16, right: 24),
 ///      child: Column(
 ///        children: [
 ///          Header(),
 ///          Body(),
-///          ignorePadding(child: Divider()),
+///          ignoreHorizontalPadding(child: Divider()),
 ///          Footer(),
 ///        ],
 ///      ),
@@ -29,7 +29,7 @@ class IgnoreHorizontalPaddingPivot extends StatelessWidget {
     super.key,
   });
 
-  final Widget Function(BuildContext context, ChildWrapper ignorePadding) builder;
+  final Widget Function(BuildContext context, ChildWrapper ignoreHorizontalPadding) builder;
 
   @override
   Widget build(BuildContext context) => LayoutBuilder(

--- a/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
+++ b/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
@@ -24,6 +24,8 @@ typedef ChildWrapper = Widget Function({required Widget child});
 ///  },
 ///);
 ///```
+/// Do not overuse this widget. If you find yourself needing this for more than just cosmetics (like `Divider`),
+/// then it might be worth revisiting the widget's layout hierarchy.
 class IgnoreHorizontalPaddingPivot extends StatelessWidget {
   const IgnoreHorizontalPaddingPivot({
     required this.builder,

--- a/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
+++ b/lib/src/widgets/layout/ignore_horizontal_padding_pivot.dart
@@ -1,3 +1,4 @@
+import 'package:defer_pointer/defer_pointer.dart';
 import 'package:flutter/material.dart';
 import 'package:v_flutter_core/src/widgets/misc/size_reporter.dart';
 
@@ -32,28 +33,32 @@ class IgnoreHorizontalPaddingPivot extends StatelessWidget {
   final Widget Function(BuildContext context, ChildWrapper ignoreHorizontalPadding) builder;
 
   @override
-  Widget build(BuildContext context) => LayoutBuilder(
-        builder: (context, constraints) => SizeReporter.builder(
-          builder: (parentSize, parentOffset) => builder(
-            context,
-            ({required child}) => SizeReporter.builder(
-              builder: (size, offset) {
-                final parentDx = parentOffset?.dx ?? 0;
-                final parentWidth = parentSize?.width ?? 0;
-                final dx = offset?.dx ?? 0;
-                final width = size?.width ?? 0;
-                final translation = (parentDx + parentWidth / 2) - (dx + width / 2);
+  Widget build(BuildContext context) => DeferredPointerHandler(
+        child: LayoutBuilder(
+          builder: (context, constraints) => SizeReporter.builder(
+            builder: (parentSize, parentOffset) => builder(
+              context,
+              ({required child}) => SizeReporter.builder(
+                builder: (size, offset) {
+                  final parentDx = parentOffset?.dx ?? 0;
+                  final parentWidth = parentSize?.width ?? 0;
+                  final dx = offset?.dx ?? 0;
+                  final width = size?.width ?? 0;
+                  final translation = (parentDx + parentWidth / 2) - (dx + width / 2);
 
-                return IntrinsicHeight(
-                  child: OverflowBox(
-                    maxWidth: parentSize?.width ?? constraints.maxWidth,
-                    child: Transform.translate(
-                      offset: Offset(translation, 0),
-                      child: child,
+                  return IntrinsicHeight(
+                    child: OverflowBox(
+                      maxWidth: parentSize?.width ?? constraints.maxWidth,
+                      child: Transform.translate(
+                        offset: Offset(translation, 0),
+                        child: DeferPointer(
+                          child: child,
+                        ),
+                      ),
                     ),
-                  ),
-                );
-              },
+                  );
+                },
+              ),
             ),
           ),
         ),

--- a/lib/src/widgets/misc/size_reporter.dart
+++ b/lib/src/widgets/misc/size_reporter.dart
@@ -43,6 +43,10 @@ class SizeReporter extends HookWidget {
 
     void _actualizeValuesAndInvokeCallback() {
       if (context.mounted) {
+        if (globalKey.size != size.value || globalKey.offset != offset.value) {
+          WidgetsBinding.instance.addPostFrameCallback((_) => _actualizeValuesAndInvokeCallback());
+        }
+
         size.value = globalKey.size;
         offset.value = globalKey.offset;
 

--- a/lib/v_flutter_core.dart
+++ b/lib/v_flutter_core.dart
@@ -58,6 +58,7 @@ export 'src/widgets/layout/flex/gap_row.dart';
 export 'src/widgets/layout/flex/separated_column.dart';
 export 'src/widgets/layout/flex/separated_flex.dart';
 export 'src/widgets/layout/flex/separated_row.dart';
+export 'src/widgets/layout/ignore_horizontal_padding_pivot.dart';
 export 'src/widgets/layout/size_class_layout.dart';
 export 'src/widgets/misc/always_scrollbar.dart';
 export 'src/widgets/misc/debug_container.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
+  defer_pointer: ^0.0.2
   easy_debounce: ^2.0.3
   entry: ^1.0.0
   flutter:


### PR DESCRIPTION
 This widget is aware of its width. In its builder parameter it supplies a `ChildWrapper` function that can be used
 as any other widget (like `Container(child: ...)`). The widgets which are wrapped in this are ignoring the horizontal
 paddings that the are imposed on them after the pivot.
 ```dart
IgnoreHorizontalPaddingPivot(
  builder: (context, ignoreHorizontalPadding) {
    return Padding(
      padding: const EdgeInsets.only(left: 16, right: 24),
      child: Column(
        children: [
          Header(),
          Body(),
          ignoreHorizontalPadding(child: Divider()),
          Footer(),
        ],
      ),
    );
  },
);
```
 Do not overuse this widget. If you find yourself needing this for more than just cosmetics (like `Divider`),
 then it might be worth revisiting the widget's layout hierarchy.


https://github.com/user-attachments/assets/03236097-bdf7-4001-b3a6-66b512d65987

